### PR TITLE
Don't bindgen nng_sockaddr* to replace u16 with nng_sockaddr_family

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,6 +51,7 @@ fn main() {
             .whitelist_type("nng_.*")
             .whitelist_function("nng_.*")
             .whitelist_var("NNG_.*")
+            .blacklist_type("nng_sockaddr.*")
             .opaque_type("nng_.*_s")
             // Generate `pub const NNG_UNIT_EVENTS` instead of `nng_unit_enum_NNG_UNIT_EVENTS`
             .prepend_enum_name(false)

--- a/build.rs
+++ b/build.rs
@@ -51,7 +51,6 @@ fn main() {
             .whitelist_type("nng_.*")
             .whitelist_function("nng_.*")
             .whitelist_var("NNG_.*")
-            .blacklist_type("nng_sockaddr.*")
             .opaque_type("nng_.*_s")
             // Generate `pub const NNG_UNIT_EVENTS` instead of `nng_unit_enum_NNG_UNIT_EVENTS`
             .prepend_enum_name(false)

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -64,6 +64,11 @@ pub const NNG_OPT_ZT_ORBIT: &'static [u8; 9usize] = b"zt:orbit\0";
 pub const NNG_OPT_ZT_DEORBIT: &'static [u8; 11usize] = b"zt:deorbit\0";
 pub const NNG_OPT_ZT_ADD_LOCAL_ADDR: &'static [u8; 18usize] = b"zt:add-local-addr\0";
 pub const NNG_OPT_ZT_CLEAR_LOCAL_ADDRS: &'static [u8; 21usize] = b"zt:clear-local-addrs\0";
+pub type __uint8_t = ::std::os::raw::c_uchar;
+pub type __uint16_t = ::std::os::raw::c_ushort;
+pub type __int32_t = ::std::os::raw::c_int;
+pub type __uint32_t = ::std::os::raw::c_uint;
+pub type __uint64_t = ::std::os::raw::c_ulong;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct nng_ctx_s {
@@ -518,7 +523,7 @@ impl Default for nng_sockaddr {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(i32)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum nng_sockaddr_family {
     NNG_AF_UNSPEC = 0,
@@ -691,7 +696,7 @@ extern "C" {
         arg3: *mut *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
-#[repr(i32)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum nng_pipe_ev {
     NNG_PIPE_EV_ADD_PRE = 0,
@@ -1483,7 +1488,7 @@ extern "C" {
 }
 pub const NNG_FLAG_ALLOC: nng_flag_enum = 1;
 pub const NNG_FLAG_NONBLOCK: nng_flag_enum = 2;
-pub type nng_flag_enum = i32;
+pub type nng_flag_enum = u32;
 extern "C" {
     pub fn nng_stats_get(arg1: *mut *mut nng_stat) -> ::std::os::raw::c_int;
 }
@@ -1505,7 +1510,7 @@ extern "C" {
 extern "C" {
     pub fn nng_stat_type(arg1: *mut nng_stat) -> ::std::os::raw::c_int;
 }
-#[repr(i32)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum nng_stat_type_enum {
     NNG_STAT_SCOPE = 0,
@@ -1518,7 +1523,7 @@ pub enum nng_stat_type_enum {
 extern "C" {
     pub fn nng_stat_unit(arg1: *mut nng_stat) -> ::std::os::raw::c_int;
 }
-#[repr(i32)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum nng_unit_enum {
     NNG_UNIT_NONE = 0,
@@ -1575,7 +1580,7 @@ pub const NNG_EBADTYPE: nng_errno_enum = 30;
 pub const NNG_EINTERNAL: nng_errno_enum = 1000;
 pub const NNG_ESYSERR: nng_errno_enum = 268435456;
 pub const NNG_ETRANERR: nng_errno_enum = 536870912;
-pub type nng_errno_enum = i32;
+pub type nng_errno_enum = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nng_url {
@@ -1807,7 +1812,7 @@ extern "C" {
 extern "C" {
     pub fn nng_wss_register() -> ::std::os::raw::c_int;
 }
-#[repr(i32)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum nng_zt_status {
     NNG_ZT_STATUS_UP = 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,14 +57,12 @@ fn example() {
 // Either bindgen generated source, or the static copy
 #[cfg(feature = "build-bindgen")]
 mod bindings {
-    pub use crate::sockaddr::*;
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 #[cfg(not(feature = "build-bindgen"))]
 mod bindings;
 
 pub use bindings::*;
-pub use sockaddr::*;
 
 impl nng_pipe {
     pub const NNG_PIPE_INITIALIZER: nng_pipe = nng_pipe {
@@ -94,85 +92,6 @@ impl nng_ctx {
     pub const NNG_CTX_INITIALIZER: nng_ctx = nng_ctx {
         _bindgen_opaque_blob: 0,
     };
-}
-
-mod sockaddr {
-
-    #[repr(u16)]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub enum nng_sockaddr_family {
-        NNG_AF_UNSPEC = 0,
-        NNG_AF_INPROC = 1,
-        NNG_AF_IPC = 2,
-        NNG_AF_INET = 3,
-        NNG_AF_INET6 = 4,
-        NNG_AF_ZT = 5,
-    }
-    impl Default for nng_sockaddr_family {
-        fn default() -> Self {
-            nng_sockaddr_family::NNG_AF_UNSPEC
-        }
-    }
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub struct nng_sockaddr_inproc {
-        pub sa_family: nng_sockaddr_family,
-        pub sa_name: [::std::os::raw::c_char; 128usize],
-    }
-    impl Default for nng_sockaddr_inproc {
-        fn default() -> Self {
-            unsafe { ::core::mem::zeroed() }
-        }
-    }
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub struct nng_sockaddr_path {
-        pub sa_family: nng_sockaddr_family,
-        pub sa_path: [::std::os::raw::c_char; 128usize],
-    }
-    impl Default for nng_sockaddr_path {
-        fn default() -> Self {
-            unsafe { ::core::mem::zeroed() }
-        }
-    }
-    pub type nng_sockaddr_ipc = nng_sockaddr_path;
-    #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
-    pub struct nng_sockaddr_in6 {
-        pub sa_family: nng_sockaddr_family,
-        pub sa_port: u16,
-        pub sa_addr: [u8; 16usize],
-    }
-    pub type nng_sockaddr_udp6 = nng_sockaddr_in6;
-    pub type nng_sockaddr_tcp6 = nng_sockaddr_in6;
-    #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
-    pub struct nng_sockaddr_in {
-        pub sa_family: nng_sockaddr_family,
-        pub sa_port: u16,
-        pub sa_addr: u32,
-    }
-    #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
-    pub struct nng_sockaddr_zt {
-        pub sa_family: nng_sockaddr_family,
-        pub sa_nwid: u64,
-        pub sa_nodeid: u64,
-        pub sa_port: u32,
-    }
-    pub type nng_sockaddr_udp = nng_sockaddr_in;
-    pub type nng_sockaddr_tcp = nng_sockaddr_in;
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub union nng_sockaddr {
-        pub s_family: nng_sockaddr_family,
-        pub s_ipc: nng_sockaddr_ipc,
-        pub s_inproc: nng_sockaddr_inproc,
-        pub s_in6: nng_sockaddr_in6,
-        pub s_in: nng_sockaddr_in,
-        pub s_zt: nng_sockaddr_zt,
-        _bindgen_union_align: [u64; 17usize],
-    }
 }
 
 impl nng_stat_type_enum {
@@ -219,6 +138,21 @@ impl nng_pipe_ev {
             value if value == NNG_PIPE_EV_ADD_PRE as i32 => Ok(NNG_PIPE_EV_ADD_PRE),
             value if value == NNG_PIPE_EV_ADD_POST as i32 => Ok(NNG_PIPE_EV_ADD_POST),
             value if value == NNG_PIPE_EV_REM_POST as i32 => Ok(NNG_PIPE_EV_REM_POST),
+            _ => Err(TryFromIntError),
+        }
+    }
+}
+
+impl nng_sockaddr_family {
+    pub fn try_from(value: i32) -> Result<Self, TryFromIntError> {
+        use nng_sockaddr_family::*;
+        match value {
+            value if value == NNG_AF_UNSPEC as i32 => Ok(NNG_AF_UNSPEC),
+            value if value == NNG_AF_INPROC as i32 => Ok(NNG_AF_INPROC),
+            value if value == NNG_AF_IPC as i32 => Ok(NNG_AF_IPC),
+            value if value == NNG_AF_INET as i32 => Ok(NNG_AF_INET),
+            value if value == NNG_AF_INET6 as i32 => Ok(NNG_AF_INET6),
+            value if value == NNG_AF_ZT as i32 => Ok(NNG_AF_ZT),
             _ => Err(TryFromIntError),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,12 +57,14 @@ fn example() {
 // Either bindgen generated source, or the static copy
 #[cfg(feature = "build-bindgen")]
 mod bindings {
+    pub use crate::sockaddr::*;
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 #[cfg(not(feature = "build-bindgen"))]
 mod bindings;
 
 pub use bindings::*;
+pub use sockaddr::*;
 
 impl nng_pipe {
     pub const NNG_PIPE_INITIALIZER: nng_pipe = nng_pipe {
@@ -92,6 +94,85 @@ impl nng_ctx {
     pub const NNG_CTX_INITIALIZER: nng_ctx = nng_ctx {
         _bindgen_opaque_blob: 0,
     };
+}
+
+mod sockaddr {
+
+    #[repr(u16)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub enum nng_sockaddr_family {
+        NNG_AF_UNSPEC = 0,
+        NNG_AF_INPROC = 1,
+        NNG_AF_IPC = 2,
+        NNG_AF_INET = 3,
+        NNG_AF_INET6 = 4,
+        NNG_AF_ZT = 5,
+    }
+    impl Default for nng_sockaddr_family {
+        fn default() -> Self {
+            nng_sockaddr_family::NNG_AF_UNSPEC
+        }
+    }
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct nng_sockaddr_inproc {
+        pub sa_family: nng_sockaddr_family,
+        pub sa_name: [::std::os::raw::c_char; 128usize],
+    }
+    impl Default for nng_sockaddr_inproc {
+        fn default() -> Self {
+            unsafe { ::core::mem::zeroed() }
+        }
+    }
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct nng_sockaddr_path {
+        pub sa_family: nng_sockaddr_family,
+        pub sa_path: [::std::os::raw::c_char; 128usize],
+    }
+    impl Default for nng_sockaddr_path {
+        fn default() -> Self {
+            unsafe { ::core::mem::zeroed() }
+        }
+    }
+    pub type nng_sockaddr_ipc = nng_sockaddr_path;
+    #[repr(C)]
+    #[derive(Debug, Default, Copy, Clone)]
+    pub struct nng_sockaddr_in6 {
+        pub sa_family: nng_sockaddr_family,
+        pub sa_port: u16,
+        pub sa_addr: [u8; 16usize],
+    }
+    pub type nng_sockaddr_udp6 = nng_sockaddr_in6;
+    pub type nng_sockaddr_tcp6 = nng_sockaddr_in6;
+    #[repr(C)]
+    #[derive(Debug, Default, Copy, Clone)]
+    pub struct nng_sockaddr_in {
+        pub sa_family: nng_sockaddr_family,
+        pub sa_port: u16,
+        pub sa_addr: u32,
+    }
+    #[repr(C)]
+    #[derive(Debug, Default, Copy, Clone)]
+    pub struct nng_sockaddr_zt {
+        pub sa_family: nng_sockaddr_family,
+        pub sa_nwid: u64,
+        pub sa_nodeid: u64,
+        pub sa_port: u32,
+    }
+    pub type nng_sockaddr_udp = nng_sockaddr_in;
+    pub type nng_sockaddr_tcp = nng_sockaddr_in;
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub union nng_sockaddr {
+        pub s_family: nng_sockaddr_family,
+        pub s_ipc: nng_sockaddr_ipc,
+        pub s_inproc: nng_sockaddr_inproc,
+        pub s_in6: nng_sockaddr_in6,
+        pub s_in: nng_sockaddr_in,
+        pub s_zt: nng_sockaddr_zt,
+        _bindgen_union_align: [u64; 17usize],
+    }
 }
 
 impl nng_stat_type_enum {


### PR DESCRIPTION
fixes #8 

Created [PR#895](https://github.com/nanomsg/nng/pull/895) to fix `nng_pipe_notify()` on the C side of things, but can't easily do that with `nng_sockaddr_family` because there's no way to create a `uint16_t` enum in C.

It's possible in Rust with `#[repr(u16)]`, so blacklist everything related to nng_sockaddr and provide it in lib.rs with `u16` replaced with `nng_sockaddr_famliy`.