### PR TITLE
Make build dependencies optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ travis-ci = { repository = "jeikabu/nng-rust", branch = "master" }
 default = ["build-nng", "nng-stats"]
 
 # Whether or not to build the NNG library
-build-nng = []
+build-nng = ["cmake"]
 # Whether or not to run bindgen
-build-bindgen = []
+build-bindgen = ["build-nng", "bindgen"]
 
 # Cmake generators
 cmake-unix = ["build-nng"]
@@ -41,8 +41,8 @@ no_std = ["cty"]
 cty = {version = "0.2", optional = true}
 
 [build-dependencies]
-cmake = "0.1"
-bindgen = "0.47"
+cmake = {version = "0.1", optional = true}
+bindgen = {version = "0.47", optional = true}
 
 [package.metadata.docs.rs]
 all-features = false

--- a/build.rs
+++ b/build.rs
@@ -1,97 +1,18 @@
-use cmake::Config;
-use std::{env, path::PathBuf};
-
 fn main() {
-    if cfg!(feature = "build-nng") {
-        let generator = generator();
-        let stats = if cfg!(feature = "nng-stats") {
-            "ON"
-        } else {
-            "OFF"
-        };
-        let tls = if cfg!(feature = "nng-tls") {
-            "ON"
-        } else {
-            "OFF"
-        };
-
-        // Run cmake to build nng
-        let dst = Config::new("nng")
-            .generator(generator.0)
-            .define("NNG_TESTS", "OFF")
-            .define("NNG_TOOLS", "OFF")
-            .define("NNG_ENABLE_STATS", stats)
-            .define("NNG_ENABLE_TLS", tls)
-            .build();
-
-        // Check output of `cargo build --verbose`, should see something like:
-        // -L native=/path/runng/target/debug/build/runng-sys-abc1234/out
-        // That contains output from cmake
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join("lib").display()
-        );
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join("lib64").display()
-        );
-
-        println!("cargo:rustc-link-lib=static=nng");
-    } else {
-        println!("cargo:rustc-link-lib=dylib=nng");
-    }
-
-    if cfg!(feature = "build-bindgen") {
-        let mut builder = bindgen::Builder::default()
-            // This is needed if use `#include <nng.h>` instead of `#include "path/nng.h"` in wrapper.h
-            //.clang_arg("-Inng/src/")
-            .header("src/wrapper.h")
-            // #[derive(Default)]
-            .derive_default(true)
-            .whitelist_type("nng_.*")
-            .whitelist_function("nng_.*")
-            .whitelist_var("NNG_.*")
-            .opaque_type("nng_.*_s")
-            // Generate `pub const NNG_UNIT_EVENTS` instead of `nng_unit_enum_NNG_UNIT_EVENTS`
-            .prepend_enum_name(false)
-            // Generate `pub enum ...` instead of multiple `pub const ...`
-            .default_enum_style(bindgen::EnumVariation::Rust)
-            .constified_enum("nng_flag_enum")
-            // NNG_ESYSERR and NNG_ETRANERR are used like flag
-            .constified_enum("nng_errno_enum")
-            .use_core();
-
-        if cfg!(feature = "nng-compat") {
-            builder = builder.header("compat.h");
-        }
-        if cfg!(feature = "nng-supplemental") {
-            builder = builder.header("supplemental.h");
-        }
-        if cfg!(feature = "no_std") {
-            // no_std support
-            // https://rust-embedded.github.io/book/interoperability/c-with-rust.html#automatically-generating-the-interface
-            builder = builder.ctypes_prefix("cty")
-        }
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        builder
-            .generate()
-            .expect("Unable to generate bindings")
-            .write_to_file(out_path.join("bindings.rs"))
-            .expect("Couldn't write bindings");
-    }
+    link_nng();
+    build_bindgen();
 }
 
-struct Generator(&'static str);
-
-fn generator() -> Generator {
+#[cfg(feature = "build-nng")]
+fn link_nng() {
+    struct Generator(&'static str);
     const UNIX_MAKEFILES: Generator = Generator("Unix Makefiles");
     const NINJA: Generator = Generator("Ninja");
     const VS2017_WIN64: Generator = Generator("Visual Studio 15 2017 Win64");
     const VS2017: Generator = Generator("Visual Studio 15 2017");
 
-    // Compile-time features
-    if cfg!(feature = "cmake-unix") {
+    // Compile time settings
+    let generator = if cfg!(feature = "cmake-unix") {
         UNIX_MAKEFILES
     } else if cfg!(feature = "cmake-ninja") {
         NINJA
@@ -106,5 +27,93 @@ fn generator() -> Generator {
         } else {
             VS2017_WIN64
         }
+    };
+
+    let stats = if cfg!(feature = "nng-stats") {
+        "ON"
+    } else {
+        "OFF"
+    };
+
+    let tls = if cfg!(feature = "nng-tls") {
+        "ON"
+    } else {
+        "OFF"
+    };
+
+    // Run cmake to build nng
+    let dst = cmake::Config::new("nng")
+        .generator(generator.0)
+        .define("NNG_TESTS", "OFF")
+        .define("NNG_TOOLS", "OFF")
+        .define("NNG_ENABLE_STATS", stats)
+        .define("NNG_ENABLE_TLS", tls)
+        .build();
+
+    // Check output of `cargo build --verbose`, should see something like:
+    // -L native=/path/runng/target/debug/build/runng-sys-abc1234/out
+    // That contains output from cmake
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib").display()
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib64").display()
+    );
+
+    println!("cargo:rustc-link-lib=static=nng");
+}
+
+#[cfg(not(feature = "build-nng"))]
+fn link_nng() {
+    println!("cargo:rustc-link-lib=dylib=nng");
+}
+
+#[cfg(feature = "build-bindgen")]
+fn build_bindgen() {
+    use std::{env, path::PathBuf};
+
+    let mut builder = bindgen::Builder::default()
+        // This is needed if use `#include <nng.h>` instead of `#include "path/nng.h"` in wrapper.h
+        //.clang_arg("-Inng/src/")
+        .header("src/wrapper.h")
+        // #[derive(Default)]
+        .derive_default(true)
+        .whitelist_type("nng_.*")
+        .whitelist_function("nng_.*")
+        .whitelist_var("NNG_.*")
+        .opaque_type("nng_.*_s")
+        // Generate `pub const NNG_UNIT_EVENTS` instead of `nng_unit_enum_NNG_UNIT_EVENTS`
+        .prepend_enum_name(false)
+        // Generate `pub enum ...` instead of multiple `pub const ...`
+        .default_enum_style(bindgen::EnumVariation::Rust)
+        .constified_enum("nng_flag_enum")
+        // NNG_ESYSERR and NNG_ETRANERR are used like flag
+        .constified_enum("nng_errno_enum")
+        .use_core();
+
+    if cfg!(feature = "nng-compat") {
+        builder = builder.header("compat.h");
     }
+    if cfg!(feature = "nng-supplemental") {
+        builder = builder.header("supplemental.h");
+    }
+    if cfg!(feature = "no_std") {
+        // no_std support
+        // https://rust-embedded.github.io/book/interoperability/c-with-rust.html#automatically-generating-the-interface
+        builder = builder.ctypes_prefix("cty")
+    }
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    builder
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings");
+}
+
+#[cfg(not(feature = "build-bindgen"))]
+fn build_bindgen() {
+    // Nothing
 }


### PR DESCRIPTION
Closes #12 

I don't know if this is the best style, but `if cfg!(...)` doesn't seem to work with optional dependencies.