### PR TITLE
Add support for VS2019 cmake generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ cmake-unix = ["build-nng"]
 cmake-ninja = ["build-nng"]
 cmake-vs2017-win64 = ["build-nng"]
 cmake-vs2017 = ["build-nng"]
+cmake-vs2019 = ["build-nng"]
 
 # NNG Options
 nng-stats = ["build-nng"]
@@ -45,7 +46,7 @@ source-update-bindings = ["build-bindgen"]
 cty = {version = "0.2", optional = true}
 
 [build-dependencies]
-cmake = {version = "0.1", optional = true}
+cmake = {version = "^0.1.36", optional = true}
 bindgen = {version = "0.47", optional = true}
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Requirements:
 - `build-bindgen`: run bindgen to re-generate Rust FFI bindings to C
 - `cmake-unix`: use cmake generator "Unix Makefiles" (default on Linux/macOS)
 - `cmake-ninja`: use cmake generator "Ninja"
-- `cmake-vs2017`: use cmake generator "Visual Studio 15 2017"
-- `cmake-vs2017-win64`: use cmake generator "Visual Studio 15 2017 Win64" (default on Windows)
+- `cmake-vs2017`: use cmake generator "Visual Studio 15 2017" (default on Windows)
+- `cmake-vs2019`: use cmake generator "Visual Studio 16 2019"
 - `nng-stats`: enable NNG stats `NNG_ENABLE_STATS` (enabled by default)
 - `nng-tls`: enable TLS `NNG_ENABLE_TLS` (requires mbedTLS)
 - `nng-supplemental`: generate bindings to NNG's supplemental functions

--- a/build.rs
+++ b/build.rs
@@ -9,16 +9,17 @@ fn link_nng() {
     const UNIX_MAKEFILES: Generator = Generator("Unix Makefiles");
     const NINJA: Generator = Generator("Ninja");
     const VS2017: Generator = Generator("Visual Studio 15 2017");
+    const VS2019: Generator = Generator("Visual Studio 16 2019");
 
     // Compile time settings
     let generator = if cfg!(feature = "cmake-unix") {
         UNIX_MAKEFILES
     } else if cfg!(feature = "cmake-ninja") {
         NINJA
-    } else if cfg!(feature = "cmake-vs2017-win64") {
+    } else if cfg!(feature = "cmake-vs2017") || cfg!(feature = "cmake-vs2017-win64") {
         VS2017
-    } else if cfg!(feature = "cmake-vs2017") {
-        VS2017
+    } else if cfg!(feature = "cmake-vs2019") {
+        VS2019
     } else {
         // Default generators
         if cfg!(target_family = "unix") {


### PR DESCRIPTION
- Turns out issue #20 was caused by cmake-rs >=0.1.36 adding x64 args so
generator like "Visual Studio xxx Win64" no longer works